### PR TITLE
feat(ui): Reduced peak memory consumption on the applicaiton start. U…

### DIFF
--- a/Alerting.ML.App/App.axaml
+++ b/Alerting.ML.App/App.axaml
@@ -139,6 +139,11 @@
                 <Setter Property="Foreground" Value="{StaticResource Color.FailureForeground}" />
                 <Setter Property="BorderBrush" Value="{StaticResource Color.FailurePanelBorder}" />
             </Style>
+            <Style Selector="^[Content=Loading]">
+                <Setter Property="Background" Value="{StaticResource Color.FailurePanel}" />
+                <Setter Property="Foreground" Value="{StaticResource Color.FailureForeground}" />
+                <Setter Property="BorderBrush" Value="{StaticResource Color.FailurePanelBorder}" />
+            </Style>
         </Style>
 
     </Application.Styles>

--- a/Alerting.ML.App/DesignTimeExtensions/DesignTime.cs
+++ b/Alerting.ML.App/DesignTimeExtensions/DesignTime.cs
@@ -1,10 +1,15 @@
-﻿using ReactiveUI;
+﻿using Alerting.ML.App.Model.Training;
+using Alerting.ML.Engine.Storage;
+using ReactiveUI;
 
 namespace Alerting.ML.App.DesignTimeExtensions;
 
 public static class DesignTime
 {
     public static IScreen MockScreen { get; } = new MockScreen();
+
+    public static IBackgroundTrainingOrchestrator MockOrchestrator { get; } =
+        new BackgroundTrainingOrchestrator(new InMemoryEventStore());
 }
 
 internal class MockScreen : IScreen

--- a/Alerting.ML.App/Model/Training/BackgroundTrainingOrchestrator.cs
+++ b/Alerting.ML.App/Model/Training/BackgroundTrainingOrchestrator.cs
@@ -7,6 +7,7 @@ using Alerting.ML.Engine;
 using Alerting.ML.Engine.Optimizer;
 using Alerting.ML.Engine.Optimizer.Events;
 using Alerting.ML.Engine.Storage;
+using Avalonia.Threading;
 
 namespace Alerting.ML.App.Model.Training;
 

--- a/Alerting.ML.App/Model/Training/ITrainingSession.cs
+++ b/Alerting.ML.App/Model/Training/ITrainingSession.cs
@@ -10,7 +10,7 @@ namespace Alerting.ML.App.Model.Training;
 public interface ITrainingSession
 {
     Guid Id { get; }
-    string Name { get; }
+    string? Name { get; }
     ObservableCollection<double> PopulationDiversity { get; }
     ObservableCollection<double> AverageGenerationFitness { get; }
     ObservableCollection<double> BestGenerationFitness { get; }
@@ -38,5 +38,6 @@ public enum TrainingState
     Training = 1,
     Paused = 2,
     Completed = 3,
-    Failed = 4
+    Failed = 4,
+    Loading = 5
 }

--- a/Alerting.ML.App/Views/Overview/OverviewView.axaml
+++ b/Alerting.ML.App/Views/Overview/OverviewView.axaml
@@ -24,9 +24,6 @@
                         <Label Content="Fine-tune alert detection rules" />
                     </StackPanel>
                 </StackPanel>
-                <Button Grid.Column="1" Theme="{StaticResource TransparentButton}" HorizontalAlignment="Right"
-                        Width="36" Height="36" Content="⚙" VerticalContentAlignment="Center"
-                        HorizontalContentAlignment="Center" Padding="0" />
             </Grid>
         </Border>
         <!-- Filters -->

--- a/Alerting.ML.App/Views/Training/TrainingViewModel.cs
+++ b/Alerting.ML.App/Views/Training/TrainingViewModel.cs
@@ -32,11 +32,13 @@ public class TrainingViewModel : RoutableViewModelBase
             })
             .DisposeWith(Disposables);
 
-        ResumeCommand =
-            ReactiveCommand.Create(() => session.Start(ConfigurationBuilder.Apply(session.CurrentConfiguration!)),
-                this.WhenAnyValue(model => model.Session.State, state => state == TrainingState.Paused));
+        ResumeCommand = ReactiveCommand.Create(
+            () => session.Start(ConfigurationBuilder.Apply(session.CurrentConfiguration!)),
+            this.WhenAnyValue(model => model.Session.State, state => state == TrainingState.Paused)
+                .ObserveOn(RxApp.MainThreadScheduler));
         PauseCommand = ReactiveCommand.Create(session.Stop,
-            this.WhenAnyValue(model => model.Session.State, state => state == TrainingState.Training));
+            this.WhenAnyValue(model => model.Session.State, state => state == TrainingState.Training)
+                .ObserveOn(RxApp.MainThreadScheduler));
     }
 
     public ReactiveCommand<Unit, Unit> ViewResultsCommand { get; }

--- a/Alerting.ML.Engine/Optimizer/Events/StateInitializedEvent.cs
+++ b/Alerting.ML.Engine/Optimizer/Events/StateInitializedEvent.cs
@@ -31,7 +31,12 @@ public record StateInitializedEvent<T>(
     IAlertScoreCalculator AlertScoreCalculator,
     IConfigurationFactory<T> ConfigurationFactory,
     int AggregateVersion)
-    : IEvent
-    where T : AlertConfiguration
-{
-}
+    : StateInitializedEvent(Id, CreatedAt, Name, ProviderName, AggregateVersion)
+    where T : AlertConfiguration;
+
+public record StateInitializedEvent(
+    Guid Id,
+    DateTime CreatedAt,
+    string Name,
+    string ProviderName,
+    int AggregateVersion) : IEvent;

--- a/Alerting.ML.Engine/Optimizer/GeneticOptimizerStateMachine.cs
+++ b/Alerting.ML.Engine/Optimizer/GeneticOptimizerStateMachine.cs
@@ -108,18 +108,6 @@ public class GeneticOptimizerStateMachine<T> : IGeneticOptimizer
     }
 
     /// <inheritdoc />
-    public Guid Id => current.Id;
-
-    /// <inheritdoc />
-    public string Name => current?.Name ?? "Uninitialized";
-
-    /// <inheritdoc />
-    public string ProviderName => current.ProviderName ?? "Uninitialized";
-
-    /// <inheritdoc />
-    public DateTime CreatedAt => current.CreatedAt;
-
-    /// <inheritdoc />
     public async IAsyncEnumerable<IEvent> Hydrate(Guid aggregateId)
     {
         await foreach (var @event in store.GetAll(aggregateId, CancellationToken.None))

--- a/Alerting.ML.Engine/Optimizer/IGeneticOptimizer.cs
+++ b/Alerting.ML.Engine/Optimizer/IGeneticOptimizer.cs
@@ -9,26 +9,6 @@ namespace Alerting.ML.Engine.Optimizer;
 public interface IGeneticOptimizer
 {
     /// <summary>
-    ///     The Id of optimization.
-    /// </summary>
-    public Guid Id { get; }
-
-    /// <summary>
-    ///     Friendly name of the optimization.
-    /// </summary>
-    public string Name { get; }
-
-    /// <summary>
-    ///     Friendly name of the alert provider used in this optimizer.
-    /// </summary>
-    public string ProviderName { get; }
-
-    /// <summary>
-    ///     DateTime when optimization was created.
-    /// </summary>
-    public DateTime CreatedAt { get; }
-
-    /// <summary>
     ///     Initializes current instance of optimizer from event store.
     /// </summary>
     /// <param name="aggregateId"></param>


### PR DESCRIPTION
…pdated event store serialization/deserialization to be asynchronous without intermediate strings allocations.

Startup Memory profile before (peak 1.5Gb):
<img width="1118" height="388" alt="image" src="https://github.com/user-attachments/assets/66d719f8-aa3b-4dff-a406-ffc2d291a7ac" />

Startup Memory profile after (peak 0.7Gb):
<img width="1132" height="386" alt="image" src="https://github.com/user-attachments/assets/b101b077-e107-4a08-bfec-02ed83d373d9" />
